### PR TITLE
Type error in mapper() when calling current() on an empty collection

### DIFF
--- a/test/unit/CurrentOnEmptyCollectionTest.php
+++ b/test/unit/CurrentOnEmptyCollectionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Commercetools\UnitTest;
+
+use Commercetools\Api\Models\Common\BaseResourceCollection;
+use PHPUnit\Framework\TestCase;
+
+class CurrentOnEmptyCollectionTest extends TestCase
+{
+    public function testCurrentOnEmptyCollection(): void
+    {
+        $collection = new BaseResourceCollection();
+
+        static::assertNull($collection->current());
+    }
+}


### PR DESCRIPTION
⚠️ This is currently only a reproducer for the issue. I get the following output when running the test:

```
vendor/bin/phpunit test/unit/CurrentOnEmptyCollectionTest.php              
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.8
Configuration: /Users/dbr/workspace/commercetools/commercetools-sdk-php-v2/phpunit.xml.dist

E                                                                   1 / 1 (100%)

Time: 00:00.004, Memory: 6.00 MB

There was 1 error:

1) Commercetools\UnitTest\CurrentOnEmptyCollectionTest::testCurrentOnEmptyCollection
TypeError: Commercetools\Api\Models\Common\BaseResourceCollection::Commercetools\Api\Models\Common\{closure}(): Argument #1 ($index) must be of type int, null given

/Users/dbr/workspace/commercetools/commercetools-sdk-php-v2/lib/commercetools-api/src/Models/Common/BaseResourceCollection.php:47
/Users/dbr/workspace/commercetools/commercetools-sdk-php-v2/lib/commercetools-base/src/Base/MapperIterator.php:28
/Users/dbr/workspace/commercetools/commercetools-sdk-php-v2/lib/commercetools-base/src/Base/MapperSequence.php:161
/Users/dbr/workspace/commercetools/commercetools-sdk-php-v2/test/unit/CurrentOnEmptyCollectionTest.php:16

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.

```

Fixes #41