### PR TITLE
Use CustomObjectModel for 200 in ByProjectKeyCustomObjectsPost

### DIFF
--- a/lib/commercetools-api/src/Client/Resource/ByProjectKeyCustomObjectsPost.php
+++ b/lib/commercetools-api/src/Client/Resource/ByProjectKeyCustomObjectsPost.php
@@ -57,6 +57,10 @@ class ByProjectKeyCustomObjectsPost extends ApiRequest implements Expandable, De
         }
         if (is_null($resultType)) {
             switch ($response->getStatusCode()) {
+                case '200':
+                    $resultType = CustomObjectModel::class;
+
+                    break;
                 case '201':
                     $resultType = CustomObjectModel::class;
 


### PR DESCRIPTION
The response of a custom object with version 1 is 201 (created) but with 2 or higher it will change to 200 (ok).

General question: Is the spec in the upstream repository public or internal where you will change this?