### PR TITLE
Upgraded filesystem adapter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "psr/log": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
-    "cache/filesystem-adapter": "^1.0",
+    "cache/filesystem-adapter": "^1.1.0",
     "ramsey/uuid": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
Upgraded file system adapter version from 1.0 to 1.1.0 because 1.0 is not supported in PHP 8.0