### PR TITLE
set DISCRIMINATOR_VALUE in message model to null

### DIFF
--- a/lib/commercetools-api/src/Models/Message/MessageModel.php
+++ b/lib/commercetools-api/src/Models/Message/MessageModel.php
@@ -28,7 +28,7 @@ use stdClass;
  */
 final class MessageModel extends JsonObjectModel implements Message
 {
-    public const DISCRIMINATOR_VALUE = '';
+    public const DISCRIMINATOR_VALUE = null;
     /**
      * @var ?string
      */


### PR DESCRIPTION
### Fixes
Issue #89 

> When I read the messages from the messages endpoint, I get a list of messages but cant differentiate them, because getType always returns null although the MessageModel has the correct value in self::FIELD_TYPE.