### PR TITLE
Update reference page

### DIFF
--- a/doxygen_config
+++ b/doxygen_config
@@ -53,7 +53,7 @@ PROJECT_NUMBER         = $(PROJECT_NUMBER)
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "The platform, import-api and ml-api PHP sdks generated from our api reference."
+PROJECT_BRIEF          = "The platform and import-api PHP sdks generated from our api reference."
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55


### PR DESCRIPTION
Hi @barbara79 

I noticed that the following page still references Machine Learning (ml-api) in the title: https://commercetools.github.io/commercetools-sdk-php-v2/docs/html/index.html

I assume this is the file to change it, please assist if it is not.